### PR TITLE
Some quick tests

### DIFF
--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -65,6 +65,35 @@ describe R10K::Action::Deploy::Environment do
       end
     end
 
+    describe "postrun" do
+      context "basic postrun hook" do
+        let(:settings) { { postrun: ["/path/to/executable", "arg1", "arg2"] } }
+        let(:deployment) { R10K::Deployment.new(mock_config.merge(settings)) }
+
+        before do
+          expect(R10K::Deployment).to receive(:new).and_return(deployment)
+        end
+
+        subject do
+          described_class.new( {config: "/some/nonexistent/path" },
+                               %w[first],
+                               settings                             )
+        end
+
+        it "is passed to Subprocess" do
+          mock_subprocess = double
+          allow(mock_subprocess).to receive(:logger=)
+          expect(mock_subprocess).to receive(:execute)
+
+          expect(R10K::Util::Subprocess).to receive(:new).
+            with(["/path/to/executable", "arg1", "arg2"]).
+            and_return(mock_subprocess)
+
+          subject.call
+        end
+      end
+    end
+
     describe "purge_levels" do
       let(:settings) { { deploy: { purge_levels: purge_levels } } }
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -92,6 +92,61 @@ describe R10K::Action::Deploy::Environment do
           subject.call
         end
       end
+
+      context "supports environments" do
+        context "when one environment" do
+          let(:settings) { { postrun: ["/generate/types/wrapper", "$environment"] } }
+          let(:deployment) { R10K::Deployment.new(mock_config.merge(settings)) }
+
+          before do
+            expect(R10K::Deployment).to receive(:new).and_return(deployment)
+          end
+
+          subject do
+            described_class.new( {config: "/some/nonexistent/path" },
+                                 %w[first],
+                                 settings                             )
+          end
+
+          it "properly substitutes the environment" do
+            mock_subprocess = double
+            allow(mock_subprocess).to receive(:logger=)
+            expect(mock_subprocess).to receive(:execute)
+
+            expect(R10K::Util::Subprocess).to receive(:new).
+              with(["/generate/types/wrapper", "first"]).
+              and_return(mock_subprocess)
+
+            subject.call
+          end
+        end
+        context "when many environments" do
+          let(:settings) { { postrun: ["/generate/types/wrapper", "$environment"] } }
+          let(:deployment) { R10K::Deployment.new(mock_config.merge(settings)) }
+
+          before do
+            expect(R10K::Deployment).to receive(:new).and_return(deployment)
+          end
+
+          subject do
+            described_class.new( {config: "/some/nonexistent/path" },
+                                 [],
+                                 settings                             )
+          end
+
+          it "properly substitutes the environment" do
+            mock_subprocess = double
+            allow(mock_subprocess).to receive(:logger=)
+            expect(mock_subprocess).to receive(:execute)
+
+            expect(R10K::Util::Subprocess).to receive(:new).
+              with(["/generate/types/wrapper", "first second third"]).
+              and_return(mock_subprocess)
+
+            subject.call
+          end
+        end
+      end
     end
 
     describe "purge_levels" do


### PR DESCRIPTION
Here's those specs I owe you raphink.

I wrote one for environment substitution and it passed (which seemed weird, considering I thought I'd seen it fail in my test env). I figured out what I was doing before that was causing it to fail, which might not be a supported thing (grep will only match a string if they're identical, not its argument is a substring). eg https://github.com/justinstoller/r10k/compare/maint-postcmd-specs...experiment